### PR TITLE
Enable react-redux v5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0",
-    "react-redux": "^4.0.0",
+    "react-redux": "^4.0.0 || ^5.0.0",
     "redux": "^3.0.4",
     "redux-thunk": "^2.0.0",
     "webrtc-adapter-test": "^0.2.8"


### PR DESCRIPTION
Since react-redux 5.0 is considered API-wise backwards compatible change, enable it too.